### PR TITLE
Fix for #118 Missing JSON output if multiple converters

### DIFF
--- a/nodes/converter.js
+++ b/nodes/converter.js
@@ -326,7 +326,7 @@ module.exports = function (RED) {
                             }
                         });
                     } else {
-                        // indicate out.payload has been  "extended" 
+                        // indicate out.payload has been  "extended"
                         // with converted data
                         wait -= 1;
                         Object.assign(out.payload, convertedPayload);
@@ -343,12 +343,12 @@ module.exports = function (RED) {
                 // if at least one converter produced out.payload data
                 // send the combined result
                 if (wait < converters.length) {
-                   if (typeof data.linkquality !== 'undefined') {
-                       out.payload.linkquality = data.linkquality;
-                   }
+                    if (typeof data.linkquality !== 'undefined') {
+                        out.payload.linkquality = data.linkquality;
+                    }
 
-                   this.send(out);
-               }
+                    this.send(out);
+                }
             };
 
             const nodeStatusHandler = status => {

--- a/nodes/converter.js
+++ b/nodes/converter.js
@@ -316,7 +316,6 @@ module.exports = function (RED) {
                 let wait = converters.length;
 
                 const publish = convertedPayload => {
-                    wait -= 1;
                     if (config.payload === 'plain') {
                         Object.keys(convertedPayload).forEach(key => {
                             if (config.attribute === '' || config.attribute === key) {
@@ -327,14 +326,10 @@ module.exports = function (RED) {
                             }
                         });
                     } else {
+                        // indicate out.payload has been  "extended" 
+                        // with converted data
+                        wait -= 1;
                         Object.assign(out.payload, convertedPayload);
-                        if (wait === 0) {
-                            if (typeof data.linkquality !== 'undefined') {
-                                out.payload.linkquality = data.linkquality;
-                            }
-
-                            this.send(out);
-                        }
                     }
                 };
 
@@ -344,6 +339,16 @@ module.exports = function (RED) {
                         publish(convertedPayload);
                     }
                 });
+
+                // if at least one converter produced out.payload data
+                // send the combined result
+                if (wait < converters.length) {
+                   if (typeof data.linkquality !== 'undefined') {
+                       out.payload.linkquality = data.linkquality;
+                   }
+
+                   this.send(out);
+               }
             };
 
             const nodeStatusHandler = status => {


### PR DESCRIPTION
This fixes the issue #118 which basically is happening if there are multiple converters found and applied AND at least one converter does not produce publishable data as it is the case for the Hue  SML001 Motion sensor in case of occupancy message.