### PR TITLE
Fix for #160 and better serial error handling

### DIFF
--- a/nodes/shepherd.js
+++ b/nodes/shepherd.js
@@ -657,7 +657,7 @@ module.exports = function (RED) {
                 this.proxy.emit('nodeStatus', {fill: 'red', shape: 'ring', text: error.message + ', retrying'});
                 this.error(error.message);
                 
-                this.herdsman.finally().then( () => {
+                this.herdsman.stop().finally().then( () => {
                     setTimeout(() => {
                         this.connect();
                     }, 10000);


### PR DESCRIPTION
We just check for the existence of the supportsLED method and only then run the code which used to work in older zigbee-herdsman versions.
In case of problems in connect we now properly stop the zigbee adapter before trying to restart it. This was a problem uncovered by #160 but not the root cause (this was the call to a no-longer-existing method of zigbee-herdsman.