### PR TITLE
Workaround for #160, alternative to PR#161

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "mkdirp": "^1.0.4",
     "obj-ease": "^1.0.1",
     "vis": "^4.21.0",
-    "zigbee-herdsman": "^0.13.130",
+    "zigbee-herdsman": ">=0.13.130 <0.13.170",
     "zigbee-herdsman-converters": "^14.0.221"
   },
   "engines": {


### PR DESCRIPTION
`zigbee-herdsman@v0.13.170` breaks backwards compatibility by removing `supportsLED` method.
This commit works this around by setting `zigbee-herdsman` allowed versions range.